### PR TITLE
Templates aren't installed via pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
 
     packages = find_packages(exclude=['example']),
     zip_safe = False,
+    include_package_data=True,
 
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Noticed this issue when installing your fork recently - this fixed it for me so I could copy and override them.